### PR TITLE
Release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "predevals",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "predevals",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "devDependencies": {
         "d3": "^7.9.0",
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predevals",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "type": "module",
   "devDependencies": {
     "d3": "^7.9.0",


### PR DESCRIPTION
Release PR for **v1.2.0**. Closes the Phase 1 (predevals JS) step of the release wave tracked in #72.

**Version bump:** `package.json` + `package-lock.json` `1.0.0` → `1.2.0`. One-off bump bringing `package.json` in line with the release tag — it had drifted at `1.0.0` while releases were tagged through `v1.1.7`. Versioning convention being formalised in #71.

**What's in this release** (all already merged to `main`):
- #67 — Support transformed metrics + transformation definition panel *(minor feature → drives the minor bump)*
- #69 — Normalize `string | array` config fields at boundary *(patch)*
- #70 — Initially sort table on first metric column *(patch)*

`dist/predevals.bundle.js` is already current (rebuilt during the #69/#70 merges; no source change since).

**After merge:** create the GitHub release (tag `v1.2.0`, title `release-v1.2.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)