### PR TITLE
Post-v1.2.0 follow-up: bump to 1.2.1-dev and document versioning convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ python3 -m http.server 8000 -d dev-example/
 
 Then open http://127.0.0.1:8000/ in your web browser. As you make changes to `src/predevals.js`, rebuild and recopy the updated predevals.bundle.js into the `dev-example` folder and then refresh the page in your browser.
 
+## Versioning
+
+We follow a `-dev` prerelease convention for the `version` field in `package.json`:
+
+- **Between releases**, `main` carries a `-dev` suffix on the next expected version (e.g. `1.2.1-dev` after tagging `v1.2.0`).
+- **Feature PRs do not touch the version.** The bump (patch / minor / major per [SemVer](https://semver.org/)) is decided at release time based on what landed.
+- **The release PR** drops `-dev` and sets the final version (e.g. `1.2.0`).
+- **After release**, a follow-up PR bumps to the next `-dev` (e.g. `1.2.1-dev`).
+
+> [!NOTE]
+> End users load the bundle from a Git **tag** via [jsDelivr](https://www.jsdelivr.com/) (the `@v1` float resolves to the latest `v1.x.y` tag). The `version` field in `package.json` is not what gets served — it's a convention for developers to track the next release, so keep it in step with the tags.
+
 ## Creating a release
 
 ### Packaging the component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "predevals",
-  "version": "1.2.0",
+  "version": "1.2.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "predevals",
-      "version": "1.2.0",
+      "version": "1.2.1-dev",
       "devDependencies": {
         "d3": "^7.9.0",
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predevals",
-  "version": "1.2.0",
+  "version": "1.2.1-dev",
   "type": "module",
   "devDependencies": {
     "d3": "^7.9.0",


### PR DESCRIPTION
Post-release follow-up after v1.2.0.

- Bumps `package.json` to `1.2.1-dev` (the next `-dev` per our convention).
- Adds a **Versioning** section to the README documenting the `-dev`
  prerelease convention, with a note clarifying that jsDelivr serves the
  bundle from the Git tag — not `package.json`.

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)