### PR TITLE
Release predevals v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "predevals",
-  "version": "1.2.1-dev",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "predevals",
-      "version": "1.2.1-dev",
+      "version": "1.3.0",
       "devDependencies": {
         "d3": "^7.9.0",
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predevals",
-  "version": "1.2.1-dev",
+  "version": "1.3.0",
   "type": "module",
   "engines": {
     "node": ">=20.19"


### PR DESCRIPTION
Release of predevals v1.3.0.

## New Features
- **Human-readable target names** — the Target selector now shows each target's `target_name` when the hub provides one, falling back to `target_id` otherwise (#44).
- **Smarter decimal rounding** — score values are now rounded to the fewest decimal places needed to keep small non-zero scores visible instead of rounding them to `0`. Scaled relative skill remains at 2 decimals and interval coverage at 1; all other metrics adapt to the data across tables, line plots, and heatmaps (#48).

## Security
- Hardened all dropdown menus against HTML injection: option elements are now constructed safely so hub-author-supplied target/eval-set/metric names can no longer break markup or inject content.

## Internal & tooling
- **d3 is now bundled** into `dist/predevals.bundle.js` at build time rather than loaded from a CDN at runtime. Host dashboard pages that use d3 themselves (e.g. a `d3.csv` loader) must load their own copy — the bundled d3 is internal to the component and not exposed to the page.
- Added a QUnit unit-test suite and a GitHub Actions CI workflow that runs tests on every push and PR (#22).
- Refreshed `dev-example` from `dashboard-test-hub`, now including transformed metrics and `target_name` fields (#78).
- Documented the `-dev` prerelease versioning convention and dependency-bundling notes in the README (#71).
- Declared a minimum Node version (`>=20.19`).