### PR TITLE
Release v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "predevals",
-  "version": "1.3.1-dev",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "predevals",
-      "version": "1.3.1-dev",
+      "version": "1.4.0",
       "devDependencies": {
         "d3": "^7.9.0",
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predevals",
-  "version": "1.3.1-dev",
+  "version": "1.4.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"


### PR DESCRIPTION
Release v1.4.0

# Changes

| PR  | Change                                                                                         | Kind    |
|-----|------------------------------------------------------------------------------------------------|---------|
| #85 | npm audit advisories resolved; Node engines `>=20.19` → `^20.19.0 \|\| ^22.12.0 \|\| >=24.0.0` | chore   |
| #87 | Render `n` / `n_<output_type>` as `N`, plus an `N` glossary entry                              | feature |
| #89 | Fixes #57 — dates display correctly in line plots (dropped `tickvals`/`ticktext`)              | fix     |
| #90 | Fixes #56 — numeric axes sort numerically; each axis gets an explicit type                     | feature |
